### PR TITLE
edit same transaction in tx creation screen

### DIFF
--- a/iroha_tui/models/transaction_editor.py
+++ b/iroha_tui/models/transaction_editor.py
@@ -174,7 +174,9 @@ class TransactionEditorModel(BaseModel):
         if self.target_transaction is not None:
             self.target_transaction.CopyFrom(self.transaction)
         else:
-            self._application.transactions.insert(0, self.transaction)
+            insert_pos = 0
+            self._application.transactions.insert(insert_pos, self.transaction)
+            self.target_transaction = self._application.transactions[insert_pos]
 
     def save_go_back(self):
         """


### PR DESCRIPTION
Signed-off-by: Mikhail Boldyrev <miboldyrev@gmail.com>

before this change, when we create a new tx and save it several times, each time a new tx will be added to global tx list. this is counter-intuitive and in discordance with existing tx editing, when save operation overwrites edited tx.

this change makes creating a tx behave same way, as if it was added to the global list at first saving, and then being edited, so further "save"s in the editor overwrite it.